### PR TITLE
deprecatedになったoptionを削除

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,6 @@ android {
     }
     composeOptions {
         kotlinCompilerExtensionVersion composeVersion
-        kotlinCompilerVersion kotlinVersion
     }
 
     testOptions {


### PR DESCRIPTION
```
ComposeOptions.kotlinCompilerVersion is deprecated. Compose now uses the kotlin compiler defined in your buildscript.
```

がでてたので